### PR TITLE
destroy vmm

### DIFF
--- a/ukvm/ukvm_hv_bhyve.c
+++ b/ukvm/ukvm_hv_bhyve.c
@@ -47,7 +47,8 @@ static struct ukvm_hv *hack;
 static void cleanup_vm(void)
 {
     if (hack != NULL)
-        sysctlbyname("hw.vmm.destroy", NULL, NULL, "ukvm", 4);
+        sysctlbyname("hw.vmm.destroy", NULL, NULL,
+                     hack->b->vmname, sizeof(hack->b->vmname));
 }
 
 static void cleanup_vmfd(void)


### PR DESCRIPTION
this minor adjustment actually removes `/dev/vmm/ukvmXXXX` during shutdown... feel free to ignore this PR (or just adapt your code locally) -- needed to test whether this was the cause, and was happy to find out it actually works :)